### PR TITLE
Incorporate scope and role into generic signing key validation

### DIFF
--- a/src/AzureExtensions.FunctionToken/AzureExtensions.FunctionToken.csproj
+++ b/src/AzureExtensions.FunctionToken/AzureExtensions.FunctionToken.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="FirebaseAdmin" Version="1.9.1">
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.6.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIDConnect" Version="5.6.0" />
     <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/AzureExtensions.FunctionToken/Extensions/ClaimsPrincipalExtension.cs
+++ b/src/AzureExtensions.FunctionToken/Extensions/ClaimsPrincipalExtension.cs
@@ -31,18 +31,22 @@ namespace AzureExtensions.FunctionToken.Extensions
         /// </summary>
         public static bool IsInRole(this ClaimsPrincipal principal, IEnumerable<string> roles)
         {
-            var result = false;
             var claimRole = principal.Claims.FirstOrDefault(x => x.Type == ClaimTypes.Role);
-
-            if (claimRole != null && roles != null)
+            if (roles == null // Not Defined
+                || roles.Count() == 0 // No Roles Required
+            )
             {
-                if (claimRole.ValueType == ClaimValueTypes.String || claimRole.ValueType == typeof(string).ToString())
+                return true;
+            }
+            else if (claimRole != null) // A required role is defined and there is at least one available in principal
+            {
+                if (claimRole.ValueType == ClaimValueTypes.String || claimRole.ValueType == typeof(string).ToString()) // Ensure it is the right type
                 {
-                    result = roles.Any(s => s.Equals(claimRole.Value, StringComparison.OrdinalIgnoreCase));
+                    return roles.Any(s => s.Equals(claimRole.Value, StringComparison.OrdinalIgnoreCase)); // Check if the required roles are equal to any of the claimed roles
                 }
             }
 
-            return result;
+            return false; // not in role
         }
 
         /// <summary>

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/FunctionTokenBinding.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/FunctionTokenBinding.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using AzureExtensions.FunctionToken.FunctionBinding.Options;
 using AzureExtensions.FunctionToken.FunctionBinding.Options.Interface;
+using AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.Auth0;
 using AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.B2C;
 using AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.Firebase;
 using AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.SigningKey;
@@ -46,7 +47,7 @@ namespace AzureExtensions.FunctionToken.FunctionBinding
                         tokenAzureB2COptions,
                         attribute));
             }
-            else if (options is TokenSinginingKeyOptions tokenSinginingKeyOptions)
+            else if (options is TokenSigningKeyOptions tokenSinginingKeyOptions)
             {
                 return Task.FromResult<IValueProvider>(
                     new SigningKeyValueProvider(
@@ -60,6 +61,14 @@ namespace AzureExtensions.FunctionToken.FunctionBinding
                     new FirebaseKeyValueProvider(
                         request,
                         fireOptions,
+                        attribute));
+            }
+            else if (options is Auth0Options auth0Options)
+            {
+                return Task.FromResult<IValueProvider>(
+                    new Auth0ValueProvider(
+                        request,
+                        auth0Options,
                         attribute));
             }
             else

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/FunctionTokenBinding.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/FunctionTokenBinding.cs
@@ -49,7 +49,7 @@ namespace AzureExtensions.FunctionToken.FunctionBinding
             else if (options is TokenSinginingKeyOptions tokenSinginingKeyOptions)
             {
                 return Task.FromResult<IValueProvider>(
-                    new SingingKeyValueProvider(
+                    new SigningKeyValueProvider(
                         request,
                         tokenSinginingKeyOptions,
                         attribute));

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/Options/Auth0Options.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/Options/Auth0Options.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using AzureExtensions.FunctionToken.FunctionBinding.Options.Interface;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace AzureExtensions.FunctionToken.FunctionBinding.Options
+{
+    public sealed class Auth0Options : ITokenOptions
+    {
+        public TokenSigningKeyOptions SigningOptions { get; }
+
+        public Auth0Options(string audience)
+        {
+             ConfigurationManager<OpenIdConnectConfiguration> configManager =
+                new ConfigurationManager<OpenIdConnectConfiguration>(
+                    "https://dev-pxwhh3cr.auth0.com/.well-known/openid-configuration",
+                    new OpenIdConnectConfigurationRetriever());
+
+            OpenIdConnectConfiguration config = null;
+            config = configManager.GetConfigurationAsync().GetAwaiter().GetResult();
+            
+            SigningOptions = new TokenSigningKeyOptions()
+            {
+                SigningKey = config.JsonWebKeySet.Keys.FirstOrDefault(),
+                Issuer = config.Issuer,
+                Audience = audience,
+            };
+        }
+    }
+}

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/Options/TokenSigningKeyOptions.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/Options/TokenSigningKeyOptions.cs
@@ -3,7 +3,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace AzureExtensions.FunctionToken.FunctionBinding.Options
 {
-    public sealed class TokenSinginingKeyOptions : ITokenOptions
+    public sealed class TokenSigningKeyOptions : ITokenOptions
     {
         public JsonWebKey SigningKey { get; set; }
 

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/Auth0/Auth0ValueProvider.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/Auth0/Auth0ValueProvider.cs
@@ -1,0 +1,42 @@
+﻿using System.Security.Claims;
+using AzureExtensions.FunctionToken.FunctionBinding.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.Tokens;
+using AzureExtensions.FunctionToken.Extensions;
+using AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.SigningKey;
+
+namespace AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.Auth0
+{
+    /// <summary>
+    /// Provides values loaded from Azure B2C.
+    /// </summary>
+    internal class Auth0ValueProvider : SigningKeyValueProvider
+    {
+        
+        private const string ScopeClaimNameFromPrincipal = "scope";
+
+        /// <inheritdoc />
+        public Auth0ValueProvider(
+            HttpRequest request,
+            Auth0Options options,
+            FunctionTokenAttribute attribute)
+            : base(request, options.SigningOptions, attribute)
+        {
+        }
+
+        public Auth0ValueProvider(
+            HttpRequest request,
+            Auth0Options options,
+            FunctionTokenAttribute attribute,
+            ISecurityTokenValidator securityHandler)
+            : base(request, options.SigningOptions, attribute, securityHandler)
+        {
+        }
+
+        protected override bool IsAuthorizedForAction(ClaimsPrincipal claimsPrincipal)
+        {
+            return claimsPrincipal.IsInScope(InputAttribute.ScopeRequired, ScopeClaimNameFromPrincipal)
+                && claimsPrincipal.IsInRole(InputAttribute.Roles);
+        }
+    }
+}

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/Firebase/FirebaseKeyValueProvider.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/Firebase/FirebaseKeyValueProvider.cs
@@ -27,7 +27,7 @@ namespace AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.Firebase
             HttpRequest request,
             FireBaseOptions options,
             FunctionTokenAttribute attribute)
-            : base(request, options, attribute)
+            : base(request, options, attribute, null)
         {
             this.options = options;
         }

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/SigningKey/SigningKeyValueProvider.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/SigningKey/SigningKeyValueProvider.cs
@@ -4,7 +4,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 using AzureExtensions.FunctionToken.FunctionBinding.Options;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.IdentityModel.Tokens;
 
 namespace AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.SigningKey
@@ -14,21 +13,20 @@ namespace AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.SigningKe
     /// </summary>
     internal class SigningKeyValueProvider : BearerTokenValueProvider
     {
-        private readonly TokenSinginingKeyOptions options;
+        private readonly TokenSigningKeyOptions options;
 
         /// <inheritdoc />
         public SigningKeyValueProvider(
             HttpRequest request,
-            TokenSinginingKeyOptions options,
+            TokenSigningKeyOptions options,
             FunctionTokenAttribute attribute)
             : this(request, options, attribute, new JwtSecurityTokenHandler())
         {
-            this.options = options;
         }
 
         public SigningKeyValueProvider(
             HttpRequest request,
-            TokenSinginingKeyOptions options,
+            TokenSigningKeyOptions options,
             FunctionTokenAttribute attribute,
             ISecurityTokenValidator securityHandler)
             : base(request, options, attribute, securityHandler)

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/SigningKey/SigningKeyValueProvider.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/SigningKey/SigningKeyValueProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 using AzureExtensions.FunctionToken.FunctionBinding.Options;
 using Microsoft.AspNetCore.Http;
@@ -11,16 +12,26 @@ namespace AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.SigningKe
     /// <summary>
     /// Provides values loaded from Azure B2C.
     /// </summary>
-    internal class SingingKeyValueProvider : BearerTokenValueProvider
+    internal class SigningKeyValueProvider : BearerTokenValueProvider
     {
         private readonly TokenSinginingKeyOptions options;
 
         /// <inheritdoc />
-        public SingingKeyValueProvider(
+        public SigningKeyValueProvider(
             HttpRequest request,
             TokenSinginingKeyOptions options,
             FunctionTokenAttribute attribute)
-            : base(request, options, attribute)
+            : this(request, options, attribute, new JwtSecurityTokenHandler())
+        {
+            this.options = options;
+        }
+
+        public SigningKeyValueProvider(
+            HttpRequest request,
+            TokenSinginingKeyOptions options,
+            FunctionTokenAttribute attribute,
+            ISecurityTokenValidator securityHandler)
+            : base(request, options, attribute, securityHandler)
         {
             this.options = options;
         }

--- a/test/AzureExtensions.FunctionToken.tests/FunctionBinding/TokenProviders/Auth0/Auth0SigningKeyValueProviderTests.cs
+++ b/test/AzureExtensions.FunctionToken.tests/FunctionBinding/TokenProviders/Auth0/Auth0SigningKeyValueProviderTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using AzureExtensions.FunctionToken.FunctionBinding.Enums;
 using AzureExtensions.FunctionToken.FunctionBinding.Options;
-using AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.SigningKey;
+using AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.Auth0;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace AzureExtensions.FunctionToken.Tests
 {
-    public class SigningKeyValueProviderTests
+    public class Auth0ValueProviderTests
     {
         [Theory]
         [ClassData(typeof(UnitsTestData))]
@@ -26,25 +26,8 @@ namespace AzureExtensions.FunctionToken.Tests
             request
                 .SetupGet(r => r.HttpContext)
                 .Returns(Mock.Of<HttpContext>());
-            TokenSigningKeyOptions options = new TokenSigningKeyOptions {
-                SigningKey = JsonWebKey.Create(
-                    @"{
-                        ""alg"": ""RS256"",
-                        ""kty"": ""RSA"",
-                        ""use"": ""sig"",
-                        ""n"": ""fasdklfjahsdfkaljsnddfnlkasudvgiuq3450897uzxcvnlksdfn---aserkfjasbvdkluy3t45r"",
-                        ""e"": ""AQAB"",
-                        ""kid"": ""NKJLGHLJKHGBVKBLKJAFUYKJHBFADF"",
-                        ""x5t"": ""NKJLGHLJKHGBVKBLKJAFUYKJHBFADF"",
-                        ""x5c"": [
-                            ""hkjlgrhkljzvkzjhlgvzvdklhvzsilseujrgfoisyehfltw34to--=sdfghzksujfdhgi7tsertukjhask.fhcgfalsiyuegrht.jklw34batgfklyuasgdvkjsdrbg=""
-                        ]
+            Auth0Options options = new Auth0Options("some audience");
 
-                    }"
-                ),
-                Issuer = "http://iamanissuerofauthtokens.com",
-                Audience = "some audience",
-            };
             FunctionTokenAttribute attribute = new FunctionTokenAttribute(
                 AuthLevel.Authorized,
                 requiredScope,
@@ -69,7 +52,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     })
                 );
 
-            SigningKeyValueProvider provider = new SigningKeyValueProvider(
+            Auth0ValueProvider provider = new Auth0ValueProvider(
                 request.Object,
                 options,
                 attribute,
@@ -125,7 +108,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     null,
                     new List<Claim> 
                     {
-                        new Claim("scp", "Read"),
+                        new Claim("scope", "Read"),
                     },
                     TokenStatus.Valid
                 };
@@ -135,7 +118,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {},
                     new List<Claim> 
                     {
-                        new Claim("scp", "Read"),
+                        new Claim("scope", "Read"),
                     },
                     TokenStatus.Valid
                 };
@@ -145,7 +128,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {},
                     new List<Claim> 
                     {
-                        new Claim("scp", "Different Scope"),
+                        new Claim("scope", "Different Scope"),
                     },
                     TokenStatus.Error
                 };
@@ -155,7 +138,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     null,
                     new List<Claim> 
                     {
-                        new Claim("scp", "Different Scope"),
+                        new Claim("scope", "Different Scope"),
                     },
                     TokenStatus.Error
                 };
@@ -180,7 +163,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     null,
                     new List<Claim> 
                     {
-                        new Claim("scp", "write read"),
+                        new Claim("scope", "write read"),
                     },
                     TokenStatus.Valid
                 };
@@ -190,7 +173,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {},
                     new List<Claim> 
                     {
-                        new Claim("scp", "write read"),
+                        new Claim("scope", "write read"),
                     },
                     TokenStatus.Valid
                 };
@@ -201,7 +184,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {"user"},
                     new List<Claim> 
                     {
-                        new Claim("scp", "read"),
+                        new Claim("scope", "read"),
                     },
                     TokenStatus.Error
                 };
@@ -211,7 +194,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {"user"},
                     new List<Claim> 
                     {
-                        new Claim("scp", "write read"),
+                        new Claim("scope", "write read"),
                     },
                     TokenStatus.Error
                 };
@@ -221,7 +204,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {"user"},
                     new List<Claim> 
                     {
-                        new Claim("scp", "read"),
+                        new Claim("scope", "read"),
                         new Claim(ClaimTypes.Role, "nonuser")
                     },
                     TokenStatus.Error
@@ -232,7 +215,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {"user"},
                     new List<Claim> 
                     {
-                        new Claim("scp", "read"),
+                        new Claim("scope", "read"),
                         new Claim(ClaimTypes.Role, "user")
                     },
                     TokenStatus.Valid
@@ -243,7 +226,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {"user"},
                     new List<Claim> 
                     {
-                        new Claim("scp", "write read"),
+                        new Claim("scope", "write read"),
                         new Claim(ClaimTypes.Role, "user")
                     },
                     TokenStatus.Valid
@@ -254,7 +237,7 @@ namespace AzureExtensions.FunctionToken.Tests
                     new string[] {"admin", "user"},
                     new List<Claim> 
                     {
-                        new Claim("scp", "read"),
+                        new Claim("scope", "read"),
                         new Claim(ClaimTypes.Role, "user")
                     },
                     TokenStatus.Valid


### PR DESCRIPTION
Promoted scope checking to the base BearerTokenValueProvider class giving access to each specific authentication provider's implementation

Added tests for SigningKeyValueProvider to validate against roles and scopes.

Renamed SingingKeyValueProvider to SigningKeyValueProvider