### PR TITLE
Replace the bad request error message ART-6394

### DIFF
--- a/src/AzureExtensions.FunctionToken/Handler.cs
+++ b/src/AzureExtensions.FunctionToken/Handler.cs
@@ -42,7 +42,7 @@ namespace AzureExtensions.FunctionToken
             catch (Exception ex)
             {
                 logger?.LogError(ex.Message, ex);
-                return new BadRequestObjectResult(ex.Message);
+                return new BadRequestObjectResult("Provide a valid [Bearer ******] token in the 'Authorization' header of your request. If you don't have a token yet, use the Insomnia templates or enable the Mocking feature in the API reference documentation.");
             }
         }
 

--- a/src/AzureExtensions.FunctionToken/Handler.cs
+++ b/src/AzureExtensions.FunctionToken/Handler.cs
@@ -42,7 +42,7 @@ namespace AzureExtensions.FunctionToken
             catch (Exception ex)
             {
                 logger?.LogError(ex.Message, ex);
-                return new BadRequestObjectResult("Provide a valid [Bearer ******] token in the 'Authorization' header of your request. If you don't have a token yet, use the Insomnia templates or enable the Mocking feature in the API reference documentation.");
+                return new BadRequestObjectResult("Provide a valid [Bearer ******] token in the 'Authorization' header of your request. If you don't have a token yet, use the Insomnia demo or enable the Mocking feature in the API reference documentation.");
             }
         }
 


### PR DESCRIPTION
This message shows up on the Try It screen of the stoplight docs if you click through the default Try It steps in the initial load of the docs. Hopefully this error will guide people to use Try It with a token, use the mocking, or use a client like Insomnia.

Since this a generic library, we tried to keep the response not specific to our implementation or our products, but we did want to give some helpful guidance:

> "Provide a valid [Bearer ******] token in the 'Authorization' header of your request. If you don't have a token yet, use the Insomnia templates or enable the Mocking feature in the API reference documentation."

