### PR TITLE
ART-6428 support multiple, authorized scopes for API migrations

### DIFF
--- a/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/Auth0/Auth0ValueProvider.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/Auth0/Auth0ValueProvider.cs
@@ -35,8 +35,25 @@ namespace AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.Auth0
 
         protected override bool IsAuthorizedForAction(ClaimsPrincipal claimsPrincipal)
         {
-            return claimsPrincipal.IsInScope(InputAttribute.ScopeRequired, ScopeClaimNameFromPrincipal)
-                && claimsPrincipal.IsInRole(InputAttribute.Roles);
+            bool anyScopeMatch = false;
+            // if any scopes are present check them
+            if (InputAttribute.Scopes != null && InputAttribute.Scopes.Length > 0)
+            {
+                // Check each of the scopes
+                foreach(string scope in InputAttribute.Scopes)
+                {
+                    // Currently only support OR
+                    anyScopeMatch |= claimsPrincipal.IsInScope(scope, ScopeClaimNameFromPrincipal);
+                }
+            }
+            else // no scopes are present
+            {
+                // This is true by default
+                anyScopeMatch = true;
+            }
+
+            // Combine the scope and role requirements
+            return anyScopeMatch && claimsPrincipal.IsInRole(InputAttribute.Roles);
         }
     }
 }

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/B2C/BearerTokenB2CValueProvider.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/B2C/BearerTokenB2CValueProvider.cs
@@ -86,8 +86,11 @@ namespace AzureExtensions.FunctionToken.FunctionBinding.TokenProviders.B2C
 
         protected override bool IsAuthorizedForAction(ClaimsPrincipal claimsPrincipal)
         {
-            return claimsPrincipal.IsInScope(InputAttribute.ScopeRequired, ScopeClaimNameFromPrincipal)
-                && claimsPrincipal.IsInRole(InputAttribute.Roles);
+            return claimsPrincipal.IsInScope(
+                InputAttribute != null && InputAttribute.Scopes.Length > 0 ? InputAttribute.Scopes[0] : "", 
+                ScopeClaimNameFromPrincipal
+            )
+            && claimsPrincipal.IsInRole(InputAttribute.Roles);
         }
     }
 }

--- a/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/BearerTokenValueProvider.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionBinding/TokenProviders/BearerTokenValueProvider.cs
@@ -105,8 +105,10 @@ namespace AzureExtensions.FunctionToken.FunctionBinding.TokenProviders
         /// </summary>
         protected virtual bool IsAuthorizedForAction(ClaimsPrincipal claimsPrincipal)
         {
-            return claimsPrincipal.IsInScope(InputAttribute.ScopeRequired)
-                && claimsPrincipal.IsInRole(InputAttribute.Roles);
+            return claimsPrincipal.IsInScope(
+                InputAttribute != null && InputAttribute.Scopes.Length > 0 ? InputAttribute.Scopes[0] : ""
+            )
+            && claimsPrincipal.IsInRole(InputAttribute.Roles);
         }
     }
 }

--- a/src/AzureExtensions.FunctionToken/FunctionTokenAttribute.cs
+++ b/src/AzureExtensions.FunctionToken/FunctionTokenAttribute.cs
@@ -15,18 +15,29 @@ namespace AzureExtensions.FunctionToken
     public sealed class FunctionTokenAttribute : Attribute
     {
         public AuthLevel Auth { get;  }
-
-        public string ScopeRequired { get; }
+        public string[] Scopes { get; }
         public List<string> Roles { get; }
 
         public FunctionTokenAttribute(
             AuthLevel level,
             string scope,
             string[] roles
+        ): this (
+            level,
+            new string[] { scope },
+            roles
+        )
+        {
+        }
+        
+        public FunctionTokenAttribute(
+            AuthLevel level,
+            string[] scopes,
+            string[] roles
         )
         {
             Auth = level;
-            ScopeRequired = scope;
+            Scopes = scopes;
             Roles = new List<string>();
             if (roles != null)
             {

--- a/test/AzureExtensions.FunctionToken.tests/FunctionBinding/TokenProviders/Auth0/Auth0SigningKeyValueProviderTests.cs
+++ b/test/AzureExtensions.FunctionToken.tests/FunctionBinding/TokenProviders/Auth0/Auth0SigningKeyValueProviderTests.cs
@@ -20,7 +20,7 @@ namespace AzureExtensions.FunctionToken.Tests
     {
         [Theory]
         [ClassData(typeof(UnitsTestData))]
-        public void GetValueAsyncWorksForScope(string requiredScope, string[] authorizedRoles, List<Claim> claims, TokenStatus tokenStatus)
+        public void GetValueAsyncWorksForScope(string[] requiredScopes, string[] authorizedRoles, List<Claim> claims, TokenStatus tokenStatus)
         {
             Mock<HttpRequest> request = new Mock<HttpRequest>();
             request
@@ -61,7 +61,7 @@ namespace AzureExtensions.FunctionToken.Tests
 
             FunctionTokenAttribute attribute = new FunctionTokenAttribute(
                 AuthLevel.Authorized,
-                requiredScope,
+                requiredScopes,
                 authorizedRoles
             );
             SecurityToken mockSecurityToken = Mock.Of<SecurityToken>();
@@ -120,14 +120,20 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
 
                 yield return new object[] {
-                    "",
+                    new string[] {},
+                    new string[] {},
+                    new List<Claim>(),
+                    TokenStatus.Valid
+                };
+                yield return new object[] {
+                    new string[] {""},
                     new string[] {},
                     new List<Claim>(),
                     TokenStatus.Valid
                 };
 
                 yield return new object[] {
-                    "",
+                    new string[] {""},
                     null,
                     new List<Claim>(),
                     TokenStatus.Valid
@@ -135,7 +141,17 @@ namespace AzureExtensions.FunctionToken.Tests
 
                 // Only  scope is required
                 yield return new object[] {
-                    "read",
+                    new string[] {"read"},
+                    null,
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "Read"),
+                    },
+                    TokenStatus.Valid
+                };
+                
+                yield return new object[] {
+                    new string[] {"read", "extra"},
                     null,
                     new List<Claim> 
                     {
@@ -145,7 +161,7 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
                     new string[] {},
                     new List<Claim> 
                     {
@@ -155,7 +171,27 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read", "extra" },
+                    new string[] {},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "Read"),
+                    },
+                    TokenStatus.Valid
+                };
+
+                yield return new object[] {
+                    new string[] { "extra1", "read", "extra2" },
+                    new string[] {},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "Read"),
+                    },
+                    TokenStatus.Valid
+                };
+
+                yield return new object[] {
+                    new string[] { "read" },
                     new string[] {},
                     new List<Claim> 
                     {
@@ -165,7 +201,7 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
                     null,
                     new List<Claim> 
                     {
@@ -175,14 +211,28 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
                 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
                     null,
                     new List<Claim> (),
                     TokenStatus.Error
                 };
                 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
+                    new string[] {},
+                    new List<Claim> (),
+                    TokenStatus.Error
+                };
+
+                yield return new object[] {
+                    new string[] { "read", "write"},
+                    null,
+                    new List<Claim> (),
+                    TokenStatus.Error
+                };
+                
+                yield return new object[] {
+                    new string[] { "read", "write"},
                     new string[] {},
                     new List<Claim> (),
                     TokenStatus.Error
@@ -190,7 +240,7 @@ namespace AzureExtensions.FunctionToken.Tests
 
                 // Handle multiple scopes in returned claim
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
                     null,
                     new List<Claim> 
                     {
@@ -200,7 +250,7 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
                     new string[] {},
                     new List<Claim> 
                     {
@@ -209,9 +259,28 @@ namespace AzureExtensions.FunctionToken.Tests
                     TokenStatus.Valid
                 };
                 
+                yield return new object[] {
+                    new string[] { "read", "write" },
+                    null,
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "write read"),
+                    },
+                    TokenStatus.Valid
+                };
+
+                yield return new object[] {
+                    new string[] { "read", "write" },
+                    new string[] {},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "write read"),
+                    },
+                    TokenStatus.Valid
+                };
                 // Scope and Role Required by function
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
                     new string[] {"user"},
                     new List<Claim> 
                     {
@@ -221,7 +290,7 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
                     new string[] {"user"},
                     new List<Claim> 
                     {
@@ -231,7 +300,27 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
                 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read", "write" },
+                    new string[] {"user"},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "read"),
+                    },
+                    TokenStatus.Error
+                };
+
+                yield return new object[] {
+                    new string[] { "read", "write" },
+                    new string[] {"user"},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "write read"),
+                    },
+                    TokenStatus.Error
+                };
+
+                yield return new object[] {
+                    new string[] { "read" },
                     new string[] {"user"},
                     new List<Claim> 
                     {
@@ -242,7 +331,28 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
                 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read", "write" },
+                    new string[] {"user"},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "read"),
+                        new Claim(ClaimTypes.Role, "nonuser")
+                    },
+                    TokenStatus.Error
+                };
+                yield return new object[] {
+                    new string[] { "read", "write" },
+                    new string[] {"user"},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "read write"),
+                        new Claim(ClaimTypes.Role, "nonuser")
+                    },
+                    TokenStatus.Error
+                };
+
+                yield return new object[] {
+                    new string[] { "read" },
                     new string[] {"user"},
                     new List<Claim> 
                     {
@@ -253,7 +363,7 @@ namespace AzureExtensions.FunctionToken.Tests
                 };
 
                 yield return new object[] {
-                    "read",
+                    new string[] { "read" },
                     new string[] {"user"},
                     new List<Claim> 
                     {
@@ -263,12 +373,44 @@ namespace AzureExtensions.FunctionToken.Tests
                     TokenStatus.Valid
                 };
                 
+
                 yield return new object[] {
-                    "read",
+                    new string[] { "read", "write" },
+                    new string[] {"user"},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "read"),
+                        new Claim(ClaimTypes.Role, "user")
+                    },
+                    TokenStatus.Valid
+                };
+
+                yield return new object[] {
+                    new string[] { "read", "write" },
+                    new string[] {"user"},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "write read"),
+                        new Claim(ClaimTypes.Role, "user")
+                    },
+                    TokenStatus.Valid
+                };
+                yield return new object[] {
+                    new string[] { "read" },
                     new string[] {"admin", "user"},
                     new List<Claim> 
                     {
                         new Claim("scope", "read"),
+                        new Claim(ClaimTypes.Role, "user")
+                    },
+                    TokenStatus.Valid
+                };
+                yield return new object[] {
+                    new string[] { "read", "write" },
+                    new string[] {"admin", "user"},
+                    new List<Claim> 
+                    {
+                        new Claim("scope", "read write"),
                         new Claim(ClaimTypes.Role, "user")
                     },
                     TokenStatus.Valid


### PR DESCRIPTION
In order to support migration of scope names in an API without hard, breaking changes to required scopes we need to support multiple scopes being allowed in an "any-is-authorized" fashion.

This may be extended to support arbitrary boolean logic in the future.

For SigningKeyValueProviders other than Auth0 only 1 scope is supported.